### PR TITLE
Make inactive container scrollbar hiding optional

### DIFF
--- a/config/general/scrollbars/inactive-hide.css
+++ b/config/general/scrollbars/inactive-hide.css
@@ -1,0 +1,11 @@
+body:not(.WindowFocus) ::-webkit-scrollbar,
+div:not(:hover)>::-webkit-scrollbar,
+body:not(.WindowFocus) ::-webkit-scrollbar-track ,
+div:not(:hover)>::-webkit-scrollbar-track {
+  background-color: transparent !important; 
+}
+
+body:not(.WindowFocus) ::-webkit-scrollbar-thumb ,
+div:not(:hover)>::-webkit-scrollbar-thumb {
+  display: none;
+}

--- a/config/general/scrollbars/inactive-zeroing.css
+++ b/config/general/scrollbars/inactive-zeroing.css
@@ -1,0 +1,5 @@
+body:not(.WindowFocus) ::-webkit-scrollbar,
+div:not(:hover)>::-webkit-scrollbar {
+  width: 0 !important;
+  height: 0 !important;
+}

--- a/css/core.css
+++ b/css/core.css
@@ -4810,12 +4810,6 @@ body:not(.WindowFocus) .closeButton:hover .title-area-icon-inner {
 
 /* SCROLLBAR -------------------------------------------------------------------------------------------------------- */
 
-body:not(.WindowFocus) ::-webkit-scrollbar,
-div:not(:hover)>::-webkit-scrollbar {
-  width: 0 !important;
-  height: 0 !important;
-}
-
 ::-webkit-scrollbar {
   border-radius: var(--zehn-size-radius-square) !important;
   width: var(--zehn-scrollbar-width) !important;

--- a/skin.json
+++ b/skin.json
@@ -244,6 +244,31 @@
         }
       }
     },
+    "Inactive Scrollbar Visibility Style": {
+      "description": "Hide Scrollbar when content container is inactive.",
+      "tab": "General",
+      "default": "Zeroing",
+      "values": {
+        "Remove": {
+          "TargetCss": {
+            "affects": [".*"],
+            "src": "config/general/scrollbars/inactive-zeroing.css"
+          }
+        },
+        "Hide": {
+          "TargetCss": {
+            "affects": [".*"],
+            "src": "config/general/scrollbars/inactive-hide.css"
+          }
+        },
+        "Always Visible": {
+          "TargetCss": {
+            "affects": [".*"],
+            "src": "config/general/scrollbars/inactive-show.css"
+          }
+        }
+      }
+    },
     "Show Tooltips": {
       "description": "Show tooltips and miniprofiles in the client.",
       "tab": "General",


### PR DESCRIPTION
Current behavior of an inactive container scrollbar is exceptionally distracting(text resizes, grids "jumping", etc), my proposal is to make it optional.

What this pr does:
1. Creates "Inactive Scrollbar Visibility Style" configuration dropdown placed right after "Scrollbar Style"
2. Removes inactive scroll hiding styles from core.css, places them in default dropdown option "Remove"(so default behavior is retained)
3. Implemented less distracting option "Hide" which turns scrollbar track and thumb transparent effectively making scrollbars invisible, but still retaining space
4. Added "Always Visible" option which loads empty .css, i couldn't find a way to add an option which doesn't load anything, so it's kind-of dirty hack